### PR TITLE
Reduce daily fetch size and add request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # CV ArXiv Daily
 Automatically collected computer vision papers from arXiv.
 
-> Updated on 2025.11.28
+> Updated on 2025.11.29
 > Usage instructions: [here](./docs/README.md#usage)
 
 ## Latest Papers

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,8 @@ repo_name: "cv-arxiv-daily"
 show_authors: True
 show_links: True
 show_badge: True
-max_results: 100
+# limit the per-keyword retrieval to keep the GitHub Action runtime reliable
+max_results: 5
 
 publish_readme: True
 publish_gitpage: True

--- a/daily_arxiv.py
+++ b/daily_arxiv.py
@@ -15,6 +15,7 @@ logging.basicConfig(format='[%(asctime)s %(levelname)s] %(message)s',
 base_url = "https://arxiv.paperswithcode.com/api/v0/papers/"
 github_url = "https://api.github.com/search/repositories"
 arxiv_url = "http://arxiv.org/"
+REQUEST_TIMEOUT = 5
 
 def load_config(config_file:str) -> dict:
     '''
@@ -77,7 +78,7 @@ def get_code_link(qword:str) -> str:
         "sort": "stars",
         "order": "desc"
     }
-    r = requests.get(github_url, params=params)
+    r = requests.get(github_url, params=params, timeout=REQUEST_TIMEOUT)
     results = r.json()
     code_link = None
     if results["total_count"] > 0:
@@ -125,7 +126,7 @@ def get_daily_papers(topic,query="slam", max_results=2):
         
         try:
             # source code link    
-            r = requests.get(code_url).json()
+            r = requests.get(code_url, timeout=REQUEST_TIMEOUT).json()
             repo_url = None
             if "official" in r and r["official"]:
                 repo_url = r["official"]["url"]
@@ -199,7 +200,7 @@ def update_paper_links(filename):
                     continue
                 try:
                     code_url = base_url + paper_id #TODO
-                    r = requests.get(code_url).json()
+                    r = requests.get(code_url, timeout=REQUEST_TIMEOUT).json()
                     repo_url = None
                     if "official" in r and r["official"]:
                         repo_url = r["official"]["url"]


### PR DESCRIPTION
## Summary
- limit per-keyword fetches to 5 recent results to keep the scheduled workflow light
- add request timeouts to GitHub and Papers with Code lookups to avoid long hangs when the API is slow or blocked

## Testing
- python daily_arxiv.py *(fails: proxy error when reaching arxiv API in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292e8d3a0c832c9961797df28140ae)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limit per-keyword fetches to 5 and add 5s timeouts to external API requests; update README date.
> 
> - **Data fetch/runtime**:
>   - Add `REQUEST_TIMEOUT = 5` and apply to `requests.get` for GitHub (`search/repositories`) and Papers with Code (`api/v0/papers/...`) lookups in `daily_arxiv.py`.
> - **Configuration**:
>   - Reduce `config.yaml` `max_results` from `100` to `5` (per-keyword cap) with clarifying comment.
> - **Docs**:
>   - Update `README.md` "Updated on" date to `2025.11.29`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb5e5d11867f48f94bd7c69c1a60a0dd2f2889e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->