### PR TITLE
Fix web scraping request handling

### DIFF
--- a/daily_arxiv.py
+++ b/daily_arxiv.py
@@ -188,21 +188,18 @@ def get_daily_papers(topic,query="slam", max_results=2):
         
         repo_url = fetch_official_repo(paper_id)
         try:
-            # source code link    
-            r = requests.get(code_url, timeout=REQUEST_TIMEOUT).json()
-            repo_url = None
+            # source code link
+            response = requests.get(code_url, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            r = response.json()
+
             if "official" in r and r["official"]:
-                repo_url = r["official"]["url"]
-            # TODO: not found, two more chances  
-            # else: 
-            #    repo_url = get_code_link(paper_title)
-            #    if repo_url is None:
-            #        repo_url = get_code_link(paper_key)
-            if repo_url is not None:
-                content[paper_key] = "|**{}**|**{}**|{} et.al.|[{}]({})|**[link]({})**|\n".format(
-                       update_time,paper_title,paper_first_author,paper_key,paper_url,repo_url)
-                content_to_web[paper_key] = "- {}, **{}**, {} et.al., Paper: [{}]({}), Code: **[{}]({})**".format(
-                       update_time,paper_title,paper_first_author,paper_url,paper_url,repo_url,repo_url)
+                repo_url = r["official"].get("url") or repo_url
+
+        except RequestException as exc:
+            logging.error("Failed to fetch code link for %s: %s", paper_id, exc)
+        except ValueError as exc:
+            logging.error("Invalid JSON when checking code link for %s: %s", paper_id, exc)
 
         if repo_url is not None:
             content[paper_key] = "|**{}**|**{}**|{} et.al.|[{}]({})|**[link]({})**|\n".format(


### PR DESCRIPTION
## Description
- fix the broken try/except block in `daily_arxiv.py` that prevented the scraper from running
- preserve official repository links while adding stricter request error handling for paperswithcode lookups

## Related Issue
- N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694470f30714832c80c9208d180dae18)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves PWC API request handling in `get_daily_papers` with proper status checks and exceptions, while preserving previously found official repo URLs.
> 
> - **daily_arxiv.py**:
>   - **Request handling** in `get_daily_papers` for `paperswithcode` lookup:
>     - Use `response.raise_for_status()` and safe `response.json()` parsing.
>     - Catch `RequestException` and `ValueError` with error logging.
>     - Preserve existing `repo_url` from `fetch_official_repo`; only update when `r["official"].get("url")` exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d64a545e19d2f838d2ad365cedf2e1a5fddf6e43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->