### PR TITLE
Prefer arXiv code links over Papers with Code API

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 # TODO: add papers by configuration file
-base_url: "https://arxiv.paperswithcode.com/api/v0/papers/"
+base_url: "https://paperswithcode.com/api/v0/papers/"
 user_name: "JunuHong"
 repo_name: "cv-arxiv-daily"
 show_authors: True


### PR DESCRIPTION
## Summary
- favor arXiv-surfaced code/data links (CatalyzeX, Hugging Face, DagsHub, Papers with Code widgets) when populating code repositories
- keep the Papers with Code API as a fallback with headers and retries if arXiv exposes no supported links

## Testing
- python -m compileall daily_arxiv.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944dac9b024832ca15fa58d0105f733)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefer arXiv-exposed code/data links; fall back to Papers with Code API (with headers, retries, and legacy hostname) and update callers.
> 
> - **Code link resolution**:
>   - Prefer arXiv-exposed links via new `_extract_code_link_from_arxiv_links` and `_fetch_single_arxiv_result`.
>   - Update `find_code_repository` to accept optional `arxiv_result` and use PWC API only as fallback.
>   - Call sites (`get_daily_papers`, `update_paper_links`) now pass arXiv results to `find_code_repository`.
> - **Papers with Code API**:
>   - Replace single `base_url` with `PWC_API_BASE_URLS` (primary + legacy) and try both.
>   - Add `DEFAULT_HEADERS` (custom User-Agent) and include in requests; try with/without SSL verification.
> - **Config**:
>   - Update `config.yaml` `base_url` to `https://paperswithcode.com/api/v0/papers/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d874acdf60612b737349b081f136176276b6b024. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->